### PR TITLE
feat: reset lower level version

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -142,10 +142,13 @@ export default {
             case "major":
               lastVersion = Number(semanticVersion[0]);
               semanticVersion[0] = lastVersion + 1;
+              semanticVersion[1] = 0;
+              semanticVersion[2] = 0;
               break;
             case "minor":
               lastVersion = Number(semanticVersion[1]);
               semanticVersion[1] = lastVersion + 1;
+              semanticVersion[2] = 0;
               break;
             default:
               //patch:


### PR DESCRIPTION
Previous:
- When you release a major version from `v1.47.6`, the next version will be `v2.47.6`
- When you release a minor version from `v1.47.6`, the next version will be `v1.48.6`

Next:
- When you release a major version from `v1.47.6`, the next version will be `v2.0.0`
- When you release a minor version from `v1.47.6`, the next version will be `v1.48.0`